### PR TITLE
allow numeric character

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -29,7 +29,7 @@ export class InvalidProductToken extends Error {
   constructor(t: Token) {
     super(
       [
-        "Product token MUST only contrains a-zA-Z_- characters",
+        "Product token MUST only contains a-zA-Z_- characters",
         ` at line ${t.line}, position ${t.index}`,
       ].join(""),
     );

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { UnexpectedToken, InvalidProductToken } from "./exceptions";
 import { parse, decodePath } from "./parser";
 
@@ -20,6 +21,19 @@ Allow: /foo/bar # comment
           { type: "ALLOW", path: "/foo/bar/baz$" },
           { type: "ALLOW", path: "/foo/bar" },
         ],
+      });
+    });
+
+    it("Enable to parse even numeric product token contains", () => {
+      const robots = `
+User-Agent: MJ12bot
+DisAllow: /
+`;
+      const result = parse(robots);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        userAgent: "MJ12bot",
+        rules: [{ type: "DISALLOW", path: "/" }],
       });
     });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -87,7 +87,8 @@ function parseGroup(l: Lexer): RobotRule {
   token = nextTokenIs(l, IDENT);
   // Product token must be contracted with [a-zA-Z_-]+ characters
   // see https://datatracker.ietf.org/doc/html/rfc9309#name-the-user-agent-line
-  if (token.literal !== "*" && !/^[a-zA-Z_-]+$/.test(token.literal)) {
+  // But... some rude bots (e.g MJ12bot, etc...) has numeric characters so we should pass even containing numeric characters
+  if (token.literal !== "*" && !/^[0-9a-zA-Z_-]+$/.test(token.literal)) {
     throw new InvalidProductToken(token);
   }
   rule.userAgent = token.literal;


### PR DESCRIPTION
Some rude bot user-agent like `MJ12bot` contains numeric character, it is invalid format that is specified in [RFC9309](https://datatracker.ietf.org/doc/html/rfc9309#name-the-user-agent-line). 

However, we should pass the linter so we change the format regular expression.